### PR TITLE
Allow to query Enum with stringified digits

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -139,7 +139,13 @@ module ActiveRecord
       end
 
       def serializable?(value)
-        value.blank? || mapping.has_key?(value) || mapping.has_value?(value)
+        value.blank? || mapping.has_key?(value) || mapping.has_value?(normalize_value(value))
+      end
+
+      def normalize_value(value)
+        return value.to_i if value.is_a?(::String) && value.match(/^\d+$/)
+
+        value
       end
 
       def serialize(value)

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -138,12 +138,16 @@ module ActiveRecord
         mapping.key(subtype.deserialize(value))
       end
 
+      def serializable?(value)
+        value.blank? || mapping.has_key?(value) || mapping.has_value?(value)
+      end
+
       def serialize(value)
         mapping.fetch(value, value)
       end
 
       def assert_valid_value(value)
-        unless value.blank? || mapping.has_key?(value) || mapping.has_value?(value)
+        unless serializable?(value)
           raise ArgumentError, "'#{value}' is not a valid #{name}"
         end
       end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -139,7 +139,7 @@ module ActiveRecord
       end
 
       def serializable?(value)
-        value.blank? || mapping.has_key?(value) || mapping.has_value?(normalize_value(value))
+        value.blank? || mapping.has_key?(value) || mapping.has_value?(normalize_value(value)) && super
       end
 
       def normalize_value(value)


### PR DESCRIPTION
Just exploring the idea of keeping `serializable?` within Enum,
while restoring old behavior for `where` clause as reported #41474

However it augmenting  behaviour of `assert_valid_value` by letting stringified digits in,
I'm not sure what will be affected by this, but tests pass.